### PR TITLE
Create .gitignore in gh-pages branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+*~
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Autosaved by application when editing
+######################
+*(تم الحفظ تلقائيًا).*
+*(automaticky uloženo).*
+*(Automatisch gesichert).*
+*(Autosaved).*
+*(guardado automáticamente).*
+*(enregistré automatiquement).*
+*(salvato automaticamente).*
+*（自動保存）.*
+*(자동 저장됨).*
+*(Salvo Automaticamente).*
+*(Автосохранение).*
+*(Otomatik Kaydedildi).*
+*（自动存储）.*
+*（已自動儲存）.*


### PR DESCRIPTION
This pull request adds a .gitignore file to the gh-pages branch, primarily intended to prevent the unintentional creation of files like .DS_Store files in MacOS, when the repository is looked at in Finder.