### PR TITLE
Restore Actions with change to build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./out
     - name: Archive artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ env.ZIP_NAME }}
         path: |


### PR DESCRIPTION
This updates the "upload-artifact" GitHub Action to v4, since the previous one (v2) is now no longer available.

It looks like that change alone should make the actions succeed again, so I'd recommend merging it in whenever it's possible.